### PR TITLE
Change New-AzureDataFactoryEncryptValue to support on premises Windows A...

### DIFF
--- a/src/ResourceManager/DataFactories/Commands.DataFactories.Test/UnitTests/NewDataFactoryEncryptValueTests.cs
+++ b/src/ResourceManager/DataFactories/Commands.DataFactories.Test/UnitTests/NewDataFactoryEncryptValueTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.WindowsAzure.Commands.Test.DataFactory
 
         [Fact]
         [Trait(Category.AcceptanceType, Category.CheckIn)]
-        public void TestOnPermDatasourceEncryptionWithRawJsonContent()
+        public void TestOnPremDatasourceEncryptionSQLAuth()
         {
             SecureString secureString = new SecureString();
             string expectedOutput = "My encrypted string " + Guid.NewGuid();
@@ -47,13 +47,45 @@ namespace Microsoft.WindowsAzure.Commands.Test.DataFactory
             };
 
             // Arrange
-            this.dataFactoriesClientMock.Setup(f => f.OnPremisesEncryptString(secureString, ResourceGroupName, DataFactoryName, GatewayName)).Returns(expectedOutput);
+            this.dataFactoriesClientMock.Setup(f => f.OnPremisesEncryptString(secureString, ResourceGroupName, DataFactoryName, GatewayName, null, null)).Returns(expectedOutput);
 
             // Action
             cmdlet.ExecuteCmdlet();
 
             // Assert
-            this.dataFactoriesClientMock.Verify(f => f.OnPremisesEncryptString(secureString, ResourceGroupName, DataFactoryName, GatewayName), Times.Once());
+            this.dataFactoriesClientMock.Verify(f => f.OnPremisesEncryptString(secureString, ResourceGroupName, DataFactoryName, GatewayName, null, null), Times.Once());
+            this.commandRuntimeMock.Verify(f => f.WriteObject(expectedOutput), Times.Once());
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void TestOnPremDatasourceEncryptionWinAuth()
+        {
+            SecureString secureString = new SecureString();
+            string expectedOutput = "My encrypted string " + Guid.NewGuid();
+            string WinAuthUserName = "foo";
+            SecureString winAuthPassword = new SecureString();
+
+            var cmdlet = new NewAzureDataFactoryEncryptValueCommand
+            {
+                CommandRuntime = this.commandRuntimeMock.Object,
+                DataFactoryClient = this.dataFactoriesClientMock.Object,
+                Value = secureString,
+                ResourceGroupName = ResourceGroupName,
+                DataFactoryName = DataFactoryName,
+                GatewayName = GatewayName,
+                UserName = WinAuthUserName,
+                Password = winAuthPassword
+            };
+
+            // Arrange
+            this.dataFactoriesClientMock.Setup(f => f.OnPremisesEncryptString(secureString, ResourceGroupName, DataFactoryName, GatewayName, WinAuthUserName, winAuthPassword)).Returns(expectedOutput);
+
+            // Action
+            cmdlet.ExecuteCmdlet();
+
+            // Assert
+            this.dataFactoriesClientMock.Verify(f => f.OnPremisesEncryptString(secureString, ResourceGroupName, DataFactoryName, GatewayName, WinAuthUserName, winAuthPassword), Times.Once());
             this.commandRuntimeMock.Verify(f => f.WriteObject(expectedOutput), Times.Once());
         }
     }

--- a/src/ResourceManager/DataFactories/Commands.DataFactories/Commands.DataFactories.csproj
+++ b/src/ResourceManager/DataFactories/Commands.DataFactories/Commands.DataFactories.csproj
@@ -56,7 +56,7 @@
       <HintPath>..\..\..\packages\Microsoft.DataFactories.Runtime.0.11.1-preview\lib\net45\Microsoft.DataFactories.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DataTransfer.Gateway.Encryption">
-      <HintPath>..\..\..\packages\Microsoft.DataTransfer.Gateway.Encryption.1.0.0-preview\lib\net45\Microsoft.DataTransfer.Gateway.Encryption.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.DataTransfer.Gateway.Encryption.1.1.0-preview\lib\net45\Microsoft.DataTransfer.Gateway.Encryption.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/ResourceManager/DataFactories/Commands.DataFactories/Encrypt/NewAzureDataFactoryEncryptValueCommand.cs
+++ b/src/ResourceManager/DataFactories/Commands.DataFactories/Encrypt/NewAzureDataFactoryEncryptValueCommand.cs
@@ -43,6 +43,14 @@ namespace Microsoft.Azure.Commands.DataFactories
         [Parameter(ParameterSetName = ByFactoryName, Position = 3, Mandatory = false, HelpMessage = "The gateway group name.")]
         public string GatewayName { get; set; }
 
+        [Parameter(ParameterSetName = ByFactoryObject, Position = 3, Mandatory = false, HelpMessage = "The windows authentication user name.")]
+        [Parameter(ParameterSetName = ByFactoryName, Position = 4, Mandatory = false, HelpMessage = "The windows authentication user name.")]
+        public string UserName { get; set; }
+
+        [Parameter(ParameterSetName = ByFactoryObject, Position = 4, Mandatory = false, HelpMessage = "The windows authentication password.")]
+        [Parameter(ParameterSetName = ByFactoryName, Position = 5, Mandatory = false, HelpMessage = "The windows authentication password.")]
+        public SecureString Password { get; set; }
+
         [EnvironmentPermission(SecurityAction.Demand, Unrestricted = true)]
         public override void ExecuteCmdlet()
         {
@@ -68,7 +76,7 @@ namespace Microsoft.Azure.Commands.DataFactories
             else
             {
                 // On-premises encryption with Gateway
-                encryptedValue = DataFactoryClient.OnPremisesEncryptString(Value, ResourceGroupName, DataFactoryName, GatewayName);
+                encryptedValue = DataFactoryClient.OnPremisesEncryptString(Value, ResourceGroupName, DataFactoryName, GatewayName, UserName, Password);
             }
             
             WriteObject(encryptedValue);

--- a/src/ResourceManager/DataFactories/Commands.DataFactories/Microsoft.Azure.Commands.DataFactories.dll-Help.xml
+++ b/src/ResourceManager/DataFactories/Commands.DataFactories/Microsoft.Azure.Commands.DataFactories.dll-Help.xml
@@ -2083,6 +2083,20 @@
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="4" aliases="">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the windows authentication user name. This cmdlet encrypts data for the gateway that this parameter specifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="5" aliases="">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Specifies the windows authentication password. This cmdlet encrypts data for the gateway that this parameter specifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-AzureDataFactoryEncryptValue</maml:name>
@@ -2113,6 +2127,20 @@
             <maml:para>Specifies the name of the gateway. This cmdlet encrypts data for the gateway that this parameter specifies.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="5" aliases="">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the windows authentication user name. This cmdlet encrypts data for the gateway that this parameter specifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="6" aliases="">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Specifies the windows authentication password. This cmdlet encrypts data for the gateway that this parameter specifies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
         </command:parameter>
       </command:syntaxItem>
     </command:syntax>
@@ -2177,6 +2205,30 @@
         </dev:type>
         <dev:defaultValue></dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="5" aliases="">
+        <maml:name>UserName</maml:name>
+        <maml:description>
+          <maml:para>Specifies the windows authentication user name. This cmdlet encrypts data for the gateway that this parameter specifies.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue></dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="6" aliases="">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Specifies the windows authentication password. This cmdlet encrypts data for the gateway that this parameter specifies.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue></dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes>
       <command:inputType>
@@ -2213,10 +2265,7 @@
         <dev:code>
           PS C:\&gt; $Value = ConvertTo-SecureString "Data Source=ContosoServer;Initial Catalog=catelog;user id =user123;password=password123" -AsPlainText -Force
           PS C:\&gt; New-AzureDataFactoryEncryptValue -DataFactoryName "WikiADF" -GatewayName "WikiGateway" -ResourceGroupName "ADF" -Value $Value
-          data source=ContosoServer;initial catalog=catelog;EncryptedCredential=KAAAAAABAAAQAAAAQUU5MUVBNzY4QkFCQkI3MEUwRTMxOUNFNkM0MjRDOTVDNDk3RTcyRi8XAXyE/
-          H+f3JydTkdg5t2g1eC/VtyF3NAD3idYnhrAphPJmO0pCaG5nH2IY48L3XJi7wabrlrGF+ieiWh1bwdgdxrW+t2jWPnLvT/ENUXtcevpx/dmTGKagH8TU9HLcoL1CAanb7Vkpga1B/uzRxBnVdsdtfv
-          BzxG2M810tj1WzL8lFzA1mO5GbB0+ge116y0scL1vxjerjl5Muv0r0scG3lhj+IF0sXUMITFvhQwOIqweR052E6JlfJu+mTNFLCCkpw1iV+rhRhKqJF752dBuWjzI1EoyQUE17oK4OevkquuhUbfJmzj9B
-          hGKQ+VkndAZiSw19FEGSC7JzoUe/XWEs/FJYrQCCXIeNS94J9/VzN6KPYJR1pzAYCtnhq+p8Q==
+          data source=ContosoServer;initial catalog=catelog;EncryptedCredential=KAAAAAABAAAQAAAAQUU5MUVBNzY4QkFCQkI3MEUwRTMxOUNFNkM0MjRDOTVDNDk3RTcyRi8XAXyE/H+f3JydTkdg5t2g1eC/VtyF3NAD3idYnhrAphPJmO0pCaG5nH2IY48L3XJi7wabrlrGF+ieiWh1bwdgdxrW+t2jWPnLvT/ENUXtcevpx/dmTGKagH8TU9HLcoL1CAanb7Vkpga1B/uzRxBnVdsdtfvBzxG2M810tj1WzL8lFzA1mO5GbB0+ge116y0scL1vxjerjl5Muv0r0scG3lhj+IF0sXUMITFvhQwOIqweR052E6JlfJu+mTNFLCCkpw1iV+rhRhKqJF752dBuWjzI1EoyQUE17oK4OevkquuhUbfJmzj9BhGKQ+VkndAZiSw19FEGSC7JzoUe/XWEs/FJYrQCCXIeNS94J9/VzN6KPYJR1pzAYCtnhq+p8Q==
         </dev:code>
         <dev:remarks>
           <maml:para>The first command uses the ConvertTo-SecureString cmdlet to convert the specified connection string to a SecureString object, and then stores that object in the $Value variable. For more information, type Get-Help ConvertTo-SecureString.</maml:para>
@@ -2236,14 +2285,33 @@
         <dev:code>
           PS C:\&gt; $Value = ConvertTo-SecureString "Test123" -AsPlainText -Force
           PS C:\&gt; New-AzureDataFactoryEncryptValue -DataFactoryName "WikiADF" -ResourceGroupName "ADF" -Value $Value
-          $Encrypted$String$KAAAAAABAAAQAAAAQUU5MUVBNzY4QkFCQkI3MEUwRTMxOUNFNkM0MjRDOTVDNDk3RTcyRi8XAXyE/H+f3JydTkdg5t2g1eC/VtyF3NAD3idYnhrAphPJm
-          O0pCaG5nH2IY48L3XJi7wabrlrGF+ieiWh1bwdgdxrW+t2jWPnLvT/ENUXtcevpxdmTGKagH8TU9HLcoL1CAanb7Vkpga1B/uzRxBnVdsdtfvBzxG2M810tj1WzL8lFzA1mO5GbB0+ge116y
-          0scL1vxjerjl5Muv0r0scG3lhj+IF0sXUMITFvhQwOIqweR052E6JlfJu+mTNFLCCkpw1iV+rhRhKqJF752dBuWjzI1EoyQUE17oK4OevkquuhUbfJmzj9BhGKQ+VkndAZiSw19FEGSC7JzoUe
-          /XWEs/FJYrQCCXIeNS94J9/VzN6KPYJR1pzAYCtnhq+p8Q==
+          $Encrypted$String$KAAAAAABAAAQAAAAQUU5MUVBNzY4QkFCQkI3MEUwRTMxOUNFNkM0MjRDOTVDNDk3RTcyRi8XAXyE/H+f3JydTkdg5t2g1eC/VtyF3NAD3idYnhrAphPJmO0pCaG5nH2IY48L3XJi7wabrlrGF+ieiWh1bwdgdxrW+t2jWPnLvT/ENUXtcevpxdmTGKagH8TU9HLcoL1CAanb7Vkpga1B/uzRxBnVdsdtfvBzxG2M810tj1WzL8lFzA1mO5GbB0+ge116y0scL1vxjerjl5Muv0r0scG3lhj+IF0sXUMITFvhQwOIqweR052E6JlfJu+mTNFLCCkpw1iV+rhRhKqJF752dBuWjzI1EoyQUE17oK4OevkquuhUbfJmzj9BhGKQ+VkndAZiSw19FEGSC7JzoUe/XWEs/FJYrQCCXIeNS94J9/VzN6KPYJR1pzAYCtnhq+p8Q==
         </dev:code>
         <dev:remarks>
           <maml:para>The first command uses the ConvertTo-SecureString cmdlet to convert the specified string to a SecureString object, and then stores that object in the $Value variable.</maml:para>
           <maml:para>The second command creates an encrypted value for the object stored in $Value for the specified data factory and resource group. </maml:para>
+        </dev:remarks>
+        <command:commandLines>
+          <command:commandLine>
+            <command:commandText />
+          </command:commandLine>
+        </command:commandLines>
+      </command:example>
+      <command:example>
+        <maml:title>Example 3: Encrypt a windows authentication connection string</maml:title>
+        <maml:introduction>
+          <maml:para></maml:para>
+        </maml:introduction>
+        <dev:code>
+          PS C:\&gt; $Value = ConvertTo-SecureString "Data Source=ContosoServer;Initial Catalog=catelog;Integrated Security=True" -AsPlainText -Force
+          PS C:\&gt; $Password = ConvertTo-SecureString "password" -AsPlainText -Force
+          PS C:\&gt; New-AzureDataFactoryEncryptValue -DataFactoryName "WikiADF" -GatewayName "WikiGateway" -ResourceGroupName "ADF" -Value $Value -Us -UserName "username" -Password $Password
+          data source=ContosoServer;initial catalog=catelog;EncryptedCredential=KAAAAAABAAAQAAAAQUU5MUVBNzY4QkFCQkI3MEUwRTMxOUNFNkM0MjRDOTVDNDk3RTcyRi8XAXyE/H+f3JydTkdg5t2g1eC/VtyF3NAD3idYnhrAphPJmO0pCaG5nH2IY48L3XJi7wabrlrGF+ieiWh1bwdgdxrW+t2jWPnLvT/ENUXtcevpx/dmTGKagH8TU9HLcoL1CAanb7Vkpga1B/uzRxBnVdsdtfvBzxG2M810tj1WzL8lFzA1mO5GbB0+ge116y0scL1vxjerjl5Muv0r0scG3lhj+IF0sXUMITFvhQwOIqweR052E6JlfJu+mTNFLCCkpw1iV+rhRhKqJF752dBuWjzI1EoyQUE17oK4OevkquuhUbfJmzj9BhGKQ+VkndAZiSw19FEGSC7JzoUe/XWEs/FJYrQCCXIeNS94J9/VzN6KPYJR1pzAYCtnhq+p8Q==
+        </dev:code>
+        <dev:remarks>
+          <maml:para>The first command uses the ConvertTo-SecureString cmdlet to convert the specified connection string to a SecureString object, and then stores that object in the $Value variable. For more information, type Get-Help ConvertTo-SecureString.</maml:para>
+          <maml:para>The second command uses the ConvertTo-SecureString cmdlet to convert the windows authentication password string to a SecureString object, and then stores that object in the $Password variable. For more information, type Get-Help ConvertTo-SecureString.</maml:para>
+          <maml:para>The third command creates an encrypted value for the object stored in $Value for the specified data factory, gateway, and resource group.</maml:para>
         </dev:remarks>
         <command:commandLines>
           <command:commandLine>

--- a/src/ResourceManager/DataFactories/Commands.DataFactories/Models/DataFactoryClient.Encrypt.cs
+++ b/src/ResourceManager/DataFactories/Commands.DataFactories/Models/DataFactoryClient.Encrypt.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Commands.DataFactories
                 resourceGroupName, dataFactoryName);
         }
 
-        public virtual string OnPremisesEncryptString(SecureString value, string resourceGroupName, string dataFactoryName, string gatewayName)
+        public virtual string OnPremisesEncryptString(SecureString value, string resourceGroupName, string dataFactoryName, string gatewayName, string userName, SecureString password)
         {
             if (value == null)
             {
@@ -46,12 +46,14 @@ namespace Microsoft.Azure.Commands.DataFactories
                         {
                             ServiceToken = response.ConnectionInfo.ServiceToken,
                             IdentityCertThumbprint = response.ConnectionInfo.IdentityCertThumbprint,
-                            HostServiceUri = response.ConnectionInfo.HostServiceUri
+                            HostServiceUri = response.ConnectionInfo.HostServiceUri,
+                            InstanceVersionString = response.ConnectionInfo.Version 
                         }
                 };
 
+            UserInputConnectionString connectionString = new UserInputConnectionString(value, userName, password);
             var gatewayEncryptionClient = new GatewayEncryptionClient();
-            return gatewayEncryptionClient.Encrypt(value, gatewayEncryptionInfos);
+            return gatewayEncryptionClient.Encrypt(connectionString, gatewayEncryptionInfos);
         }
     }
 }

--- a/src/ResourceManager/DataFactories/Commands.DataFactories/packages.config
+++ b/src/ResourceManager/DataFactories/Commands.DataFactories/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.DataFactories.Runtime" version="0.11.1-preview" targetFramework="net45" />
-  <package id="Microsoft.DataTransfer.Gateway.Encryption" version="1.0.0-preview" targetFramework="net45" />
+  <package id="Microsoft.DataTransfer.Gateway.Encryption" version="1.1.0-preview" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Common" version="1.4.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.1.1" targetFramework="net45" />


### PR DESCRIPTION
...uth encryption

a) Add two optional parameters "username" and "password", which will be used in Windows Auth encryption scenario.
b) Upgrade the Gateway Client Nuget package to 1.1.0 version in which the winAuth is supported.
c) Upgrade the help contents (This has been reviewed by UE).
d) A new property "Version" in ConnectionInfo object is used, so this change depends on the new version data factory nuget package. Pending the check in until the datafactory nuget package is upgraded.
